### PR TITLE
room: end round on streamer death and support restarts

### DIFF
--- a/public/join.html
+++ b/public/join.html
@@ -77,6 +77,7 @@
     const effects = [];
     // Damage numbers for floating damage display
     let damageNumbers = [];
+    let roundActive = false;
     // Smoothing for 20Hz -> 60fps render
     const smooth = new Map(); // id -> {x,y}
     const SMOOTH_TAU = 90; // ms
@@ -174,6 +175,9 @@
       if (pingIv) { clearInterval(pingIv); pingIv = null; }
       if (sendNeutralHandler) { window.removeEventListener('blur', sendNeutralHandler); sendNeutralHandler=null; }
       if (visHandler) { document.removeEventListener('visibilitychange', visHandler); visHandler=null; }
+      roundActive = false;
+      damageNumbers = [];
+      trails.clear();
     }
 
     function extractRoomId(val){
@@ -201,6 +205,7 @@
         status.textContent = 'connected';
         status.dataset.state = 'connected';
         document.body.classList.add('connected');
+        roundActive = true;
         ws.send(JSON.stringify({ type:'join_room', role:'zombie', name }));
         joinBtn.textContent = 'Leave';
         nameEl.disabled = true; shuffleBtn.disabled = true;
@@ -218,8 +223,24 @@
           } catch {}
         }
         if (msg.type === 'joined') { arena = msg.arena; playerId = msg.playerId; }
+        if (msg.type === 'round_end') {
+          roundActive = false;
+          status.textContent = 'connected • raid ended';
+          status.dataset.state = 'ended';
+          appendChat('System', 'Raid ended');
+        }
+        if (msg.type === 'round_restart') {
+          roundActive = true;
+          status.textContent = 'connected • restarting raid';
+          status.dataset.state = 'connected';
+          damageNumbers = [];
+          trails.clear();
+          prevBulletPos = new Map();
+          effects.length = 0;
+        }
         if (msg.type === 'state') {
           stateMsgCount++;
+          roundActive = msg.roundActive !== false;
           // impact effects
           const curMap = new Map(msg.bullets.map(b=>[b.id,{x:b.x,y:b.y}]));
           for (const [id,pos] of prevBulletPos) {
@@ -248,8 +269,13 @@
           }
 
           state = msg; const ping = Math.max(0, Date.now() - (msg.t||Date.now()));
-          status.textContent = `connected • ${ping} ms • players: ${msg.players.length}`; 
-          status.dataset.state = 'connected';
+          if (roundActive) {
+            status.textContent = `connected • ${ping} ms • players: ${msg.players.length}`;
+            status.dataset.state = 'connected';
+          } else {
+            status.textContent = 'connected • raid ended';
+            status.dataset.state = 'ended';
+          }
           state.remainingTime = msg.remainingTime;
           updateTimer(state.remainingTime);
           updatePlayerList(msg.players);
@@ -273,7 +299,7 @@
       });
       // Send continuous movement state for smooth input like streamer
       inputIv = setInterval(() => {
-        if (ws && ws.readyState===1) {
+        if (ws && ws.readyState===1 && roundActive) {
           const { up,down,left,right,shoot } = input;
           const aimWX = camX + (input.aimX / zoom);
           const aimWY = camY + (input.aimY / zoom);
@@ -282,7 +308,7 @@
       }, 50);
 
       // If the tab loses focus while holding a key, send a neutral input
-      sendNeutralHandler = () => { if (ws && ws.readyState===1) ws.send(JSON.stringify({ type:'input', up:false, down:false, left:false, right:false, shoot:false, melee:false, dash:false, aimX:0, aimY:0 })); };
+      sendNeutralHandler = () => { if (ws && ws.readyState===1 && roundActive) ws.send(JSON.stringify({ type:'input', up:false, down:false, left:false, right:false, shoot:false, melee:false, dash:false, aimX:0, aimY:0 })); };
       visHandler = () => { if (document.hidden) sendNeutralHandler(); };
       window.addEventListener('blur', sendNeutralHandler);
       document.addEventListener('visibilitychange', visHandler);
@@ -481,6 +507,7 @@
         ctx.save();
         ctx.shadowColor = 'rgba(0,0,0,.6)'; ctx.shadowBlur = 0;
         if (p.role==='streamer'){
+          if (p.alive === false) { ctx.restore(); continue; }
           ctx.strokeStyle = '#4caf50';
           ctx.lineWidth = 2;
           ctx.beginPath(); ctx.arc(sp.x,sp.y,10,0,Math.PI*2); ctx.stroke();

--- a/public/join.html
+++ b/public/join.html
@@ -62,6 +62,23 @@
     </aside>
   </div>
 
+  <div id="raidEndOverlay" class="raid-end-overlay hidden">
+    <div class="raid-end-card">
+      <div class="raid-end-title">Streamer Down!</div>
+      <p class="raid-end-description" id="raidEndDescription">
+        The streamer has been defeated. Waiting for the next raid...
+      </p>
+      <div class="raid-end-leaderboard" id="raidEndLeaderboardWrapper">
+        <div class="raid-end-label">Top zombies this round</div>
+        <ol id="raidEndLeaderboard"></ol>
+      </div>
+      <div class="raid-end-actions">
+        <button id="raidEndStay">Stay for restart</button>
+        <button id="raidEndLeave" class="raid-end-leave">Return to menu</button>
+      </div>
+    </div>
+  </div>
+
   <script type="module">
     import { connect, nameStorage, minimalCanvas, suppressPageHotkeys, inputController, createLatencyMonitor } from '/common.js';
 
@@ -117,6 +134,11 @@
     const chatInput = document.getElementById('chatInput');
     const chatMessagesEl = document.getElementById('chatMessages');
     const nerdToggleBtn = document.getElementById('nerdToggle');
+    const raidEndOverlay = document.getElementById('raidEndOverlay');
+    const raidEndDescription = document.getElementById('raidEndDescription');
+    const raidEndLeaderboard = document.getElementById('raidEndLeaderboard');
+    const raidEndStayBtn = document.getElementById('raidEndStay');
+    const raidEndLeaveBtn = document.getElementById('raidEndLeave');
     // Nerd panel overlay element
     const nerdPanel = document.createElement('div');
     nerdPanel.id = 'nerdPanel';
@@ -178,7 +200,76 @@
       roundActive = false;
       damageNumbers = [];
       trails.clear();
+      hideRaidEndOverlay();
     }
+
+    const roundEndCauseMessages = {
+      zombie_touch: 'The horde swarmed the streamer!',
+      ai_zombie_touch: 'An AI zombie landed the final blow.',
+      pit: 'The streamer fell into a pit.',
+      spikes: 'The streamer was impaled on spikes.',
+      poison: 'A poison cloud finished the streamer.',
+    };
+
+    function formatRoundEndCause(cause) {
+      if (!cause) return 'The streamer has been defeated!';
+      return roundEndCauseMessages[cause] || 'The streamer has been defeated!';
+    }
+
+    function renderRaidEndLeaderboard(players) {
+      if (!raidEndLeaderboard) return;
+      raidEndLeaderboard.innerHTML = '';
+      const zombies = (players || []).filter(p => p.role === 'zombie');
+      if (!zombies.length) {
+        const li = document.createElement('li');
+        li.className = 'raid-end-empty';
+        li.textContent = 'No zombies were in the raid.';
+        raidEndLeaderboard.appendChild(li);
+        return;
+      }
+      const sorted = zombies.slice().sort((a, b) => (b.score || 0) - (a.score || 0));
+      const top = sorted.slice(0, 5);
+      for (const [idx, player] of top.entries()) {
+        const li = document.createElement('li');
+        const rank = document.createElement('span');
+        rank.className = 'raid-end-rank';
+        rank.textContent = `#${idx + 1}`;
+        const name = document.createElement('span');
+        name.className = 'raid-end-name';
+        name.textContent = player.name || 'Zombie';
+        const score = document.createElement('span');
+        score.className = 'raid-end-score';
+        score.textContent = (player.score || 0).toLocaleString();
+        li.appendChild(rank);
+        li.appendChild(name);
+        li.appendChild(score);
+        raidEndLeaderboard.appendChild(li);
+      }
+    }
+
+    function showRaidEndOverlay(payload) {
+      if (!raidEndOverlay) return;
+      if (raidEndDescription) {
+        raidEndDescription.textContent = formatRoundEndCause(payload?.cause);
+      }
+      renderRaidEndLeaderboard(state.players);
+      raidEndOverlay.classList.remove('hidden');
+    }
+
+    function hideRaidEndOverlay() {
+      if (!raidEndOverlay) return;
+      raidEndOverlay.classList.add('hidden');
+    }
+
+    raidEndStayBtn?.addEventListener('click', () => {
+      hideRaidEndOverlay();
+    });
+
+    raidEndLeaveBtn?.addEventListener('click', () => {
+      hideRaidEndOverlay();
+      leave();
+      window.location.href = '/index.html';
+    });
 
     function extractRoomId(val){
       const s = String(val||'').trim();
@@ -228,6 +319,7 @@
           status.textContent = 'connected • raid ended';
           status.dataset.state = 'ended';
           appendChat('System', 'Raid ended');
+          showRaidEndOverlay(msg);
         }
         if (msg.type === 'round_restart') {
           roundActive = true;
@@ -237,6 +329,7 @@
           trails.clear();
           prevBulletPos = new Map();
           effects.length = 0;
+          hideRaidEndOverlay();
         }
         if (msg.type === 'state') {
           stateMsgCount++;
@@ -275,6 +368,7 @@
           } else {
             status.textContent = 'connected • raid ended';
             status.dataset.state = 'ended';
+            renderRaidEndLeaderboard(msg.players);
           }
           state.remainingTime = msg.remainingTime;
           updateTimer(state.remainingTime);

--- a/public/streamer.html
+++ b/public/streamer.html
@@ -398,6 +398,7 @@
       let currentHealthSegments = 0;
       let maxHealthSegments = 10;
       let isPlayerDead = false;
+      let roundActive = false;
       let gameStartTime = Date.now();
       let lastPlayerPos = { x: 0, y: 0 };
 
@@ -463,54 +464,67 @@
       }
 
       // Death screen functions
-      function showDeathScreen(playerStats) {
+      function showDeathScreen(playerStats, reason = 'streamer_dead') {
         isPlayerDead = true;
-        
+        roundActive = false;
+
         // Calculate time survived
         const timeAlive = Date.now() - gameStartTime;
         const minutes = Math.floor(timeAlive / 60000);
         const seconds = Math.floor((timeAlive % 60000) / 1000);
-        
+
+        const subtitle = deathScreenEl.querySelector('.death-subtitle');
+        if (subtitle) {
+          if (reason === 'timeout') {
+            subtitle.textContent = 'Raid Complete';
+          } else {
+            subtitle.textContent = 'Mission Statistics';
+          }
+        }
+
+        restartRaidBtn.disabled = false;
+
         // Update death screen stats
-        document.getElementById('deathEnemiesKilled').textContent = playerStats.raidStats?.enemiesKilled || 0;
-        document.getElementById('deathBossesKilled').textContent = playerStats.raidStats?.bossesKilled || 0;
-        document.getElementById('deathBulletsFired').textContent = playerStats.raidStats?.bulletsFired || 0;
-        
-        const accuracy = playerStats.raidStats?.bulletsFired > 0 
-          ? Math.round((playerStats.raidStats.bulletsHit / playerStats.raidStats.bulletsFired) * 100)
+        const stats = playerStats || {};
+        document.getElementById('deathEnemiesKilled').textContent = stats.raidStats?.enemiesKilled || 0;
+        document.getElementById('deathBossesKilled').textContent = stats.raidStats?.bossesKilled || 0;
+        document.getElementById('deathBulletsFired').textContent = stats.raidStats?.bulletsFired || 0;
+
+        const accuracy = stats.raidStats?.bulletsFired > 0
+          ? Math.round((stats.raidStats.bulletsHit / stats.raidStats.bulletsFired) * 100)
           : 0;
         document.getElementById('deathAccuracy').textContent = accuracy + '%';
-        
-        document.getElementById('deathLevel').textContent = playerStats.level || 1;
-        document.getElementById('deathTotalXP').textContent = playerStats.raidStats?.totalXPGained || 0;
-        document.getElementById('deathFinalScore').textContent = playerStats.score || 0;
+
+        document.getElementById('deathLevel').textContent = stats.level || 1;
+        document.getElementById('deathTotalXP').textContent = stats.raidStats?.totalXPGained || 0;
+        document.getElementById('deathFinalScore').textContent = stats.score || 0;
         document.getElementById('deathTimeSurvived').textContent = `${minutes}:${seconds.toString().padStart(2, '0')}`;
-        
-        document.getElementById('deathCoinsCollected').textContent = playerStats.raidStats?.coinsCollected || 0;
-        document.getElementById('deathPickupsTaken').textContent = playerStats.raidStats?.pickupsTaken || 0;
-        document.getElementById('deathDamageDealt').textContent = playerStats.raidStats?.damageDealt || 0;
-        document.getElementById('deathDamageTaken').textContent = playerStats.raidStats?.damageTaken || 0;
-        
+
+        document.getElementById('deathCoinsCollected').textContent = stats.raidStats?.coinsCollected || 0;
+        document.getElementById('deathPickupsTaken').textContent = stats.raidStats?.pickupsTaken || 0;
+        document.getElementById('deathDamageDealt').textContent = stats.raidStats?.damageDealt || 0;
+        document.getElementById('deathDamageTaken').textContent = stats.raidStats?.damageTaken || 0;
+
         // Enemy breakdown
-        const breakdown = playerStats.raidStats?.enemyBreakdown || {};
+        const breakdown = stats.raidStats?.enemyBreakdown || {};
         document.getElementById('deathBasicZombies').textContent = breakdown.basic || 0;
         document.getElementById('deathRunners').textContent = breakdown.runner || 0;
         document.getElementById('deathBrutes').textContent = breakdown.brute || 0;
         document.getElementById('deathSpitters').textContent = breakdown.spitter || 0;
         document.getElementById('deathStalkers').textContent = breakdown.stalker || 0;
         document.getElementById('deathBombers').textContent = breakdown.bomber || 0;
-        
+
         // Bosses defeated
-        const bossesDefeated = playerStats.raidStats?.bossesDefeated || [];
+        const bossesDefeated = stats.raidStats?.bossesDefeated || [];
         if (bossesDefeated.length > 0) {
           console.log('Bosses defeated:', bossesDefeated.join(', '));
         }
-        
+
         // Final upgrades
         const upgradesEl = document.getElementById('deathFinalUpgrades');
-        if (playerStats.mods && playerStats.mods.length > 0) {
+        if (stats.mods && stats.mods.length > 0) {
           upgradesEl.innerHTML = '';
-          playerStats.mods.forEach(mod => {
+          stats.mods.forEach(mod => {
             const upgradeEl = document.createElement('div');
             upgradeEl.className = 'upgrade-item';
             // Use the mod name if available, otherwise format the ID
@@ -532,20 +546,34 @@
       }
 
       function restartRaid() {
-        hideDeathScreen();
-        gameStartTime = Date.now();
-        // Trigger a new room creation
-        if (ws && ws.readyState === 1) {
-          leaveRoom(true);
-        }
-        setTimeout(() => boot(), 100);
+        if (!ws || ws.readyState !== 1) return;
+        restartRaidBtn.disabled = true;
+        ws.send(JSON.stringify({ type: 'restart_round' }));
       }
 
       function exitToMenu() {
         hideDeathScreen();
-        if (ws && ws.readyState === 1) {
-          leaveRoom(true);
-        }
+        leaveRoom(true);
+        window.location.href = '/index.html';
+      }
+
+      function handleRoundRestart() {
+        roundActive = true;
+        gameStartTime = Date.now();
+        lastPlayerPos = { x: 0, y: 0 };
+        prevBulletPos = new Map();
+        effects.length = 0;
+        muzzleFlashes.length = 0;
+        damageNumbers = [];
+        trails.clear();
+        lastHp = 100;
+        lastScore = 0;
+        upgradeQueue.length = 0;
+        currentChoices = [];
+        overlay.classList.add('hidden');
+        choiceEls.forEach((el) => { el.textContent = ''; el.disabled = true; });
+        hideDeathScreen();
+        restartRaidBtn.disabled = false;
       }
 
       function showNextUpgrade() {
@@ -672,6 +700,9 @@
           status.textContent = "connected";
           status.dataset.state = "connected";
           document.body.classList.add("connected");
+          roundActive = true;
+          gameStartTime = Date.now();
+          restartRaidBtn.disabled = false;
           const name = nameStorage().get() || "Marine";
           ws.send(
             JSON.stringify({ type: "join_room", role: "streamer", name })
@@ -713,8 +744,21 @@
             playerId = msg.playerId;
             arena = msg.arena;
           }
+          if (msg.type === 'round_end') {
+            roundActive = false;
+            const finalStats = msg.streamer || state.players.find((p) => p.id === playerId);
+            showDeathScreen(finalStats, msg.reason || 'streamer_dead');
+            status.textContent = 'connected • raid ended';
+            status.dataset.state = 'ended';
+          }
+          if (msg.type === 'round_restart') {
+            handleRoundRestart();
+            status.textContent = 'connected • restarting raid';
+            status.dataset.state = 'connected';
+          }
           if (msg.type === "state") {
             stateMsgCount++;
+            roundActive = msg.roundActive !== false;
             // detect removed bullets for small impact effect
             const curMap = new Map(
               msg.bullets.map((b) => [b.id, { x: b.x, y: b.y }])
@@ -903,8 +947,13 @@
               if (hudXpEl) hudXpEl.textContent = '0/0';
             }
             const ping = Math.max(0, Date.now() - (msg.t || Date.now()));
-            status.textContent = `connected • ${ping} ms • players: ${msg.players.length}`;
-            status.dataset.state = "connected";
+            if (roundActive) {
+              status.textContent = `connected • ${ping} ms • players: ${msg.players.length}`;
+              status.dataset.state = "connected";
+            } else {
+              status.textContent = `connected • raid ended`;
+              status.dataset.state = "ended";
+            }
             state.remainingTime = msg.remainingTime;
             updateTimer(state.remainingTime);
             updatePlayerList(msg.players);
@@ -927,20 +976,8 @@
             }
             
             // Check for death - only trigger death screen, don't auto-hide on respawn
-            if (me && (me.hp ?? 0) <= 0 && !isPlayerDead) {
-              console.log('Death detected! HP:', me.hp);
+            if (!roundActive && me && me.role === 'streamer' && me.alive === false && !isPlayerDead) {
               showDeathScreen(me);
-            }
-            
-            // Check for sudden teleportation (respawn after spike/poison death)
-            if (me && lastPlayerPos.x !== 0 && !isPlayerDead) {
-              const distMoved = Math.hypot(me.x - lastPlayerPos.x, me.y - lastPlayerPos.y);
-              const hpRestored = (me.hp ?? 0) > lastHp + 20; // HP significantly increased
-              
-              if (distMoved > 500 && hpRestored) {
-                console.log('Teleportation + HP restore detected - likely respawn! Distance:', distMoved, 'HP:', lastHp, '->', me.hp);
-                showDeathScreen(me);
-              }
             }
             
             // Update last position
@@ -965,20 +1002,13 @@
             appendChat("System", msg.message);
             
             // Check for respawn notice (pit death)
-            if (msg.message && msg.message.includes("💀 Fell into a pit! Respawning...") && !isPlayerDead) {
-              console.log('Pit death detected:', msg.message);
-              const me = state.players.find((p) => p.id === playerId);
-              if (me) {
-                showDeathScreen(me);
-              }
-            }
           }
           if (msg.type === 'upgrade_offer') {
             queueUpgrade(msg.choices || []);
           }
         });
         inputIv = setInterval(() => {
-          if (ws && ws.readyState === 1 && !isPlayerDead) {
+          if (ws && ws.readyState === 1 && !isPlayerDead && roundActive) {
             // Convert screen aim to world coordinates via camera + zoom
             const aimWX = camX + input.aimX / zoom;
             const aimWY = camY + input.aimY / zoom;
@@ -1020,7 +1050,7 @@
 
         // If focus is lost, immediately send a neutral input (interval covers it, but faster feedback helps)
         sendNeutralHandler = () => {
-          if (ws && ws.readyState === 1 && !isPlayerDead) {
+          if (ws && ws.readyState === 1 && !isPlayerDead && roundActive) {
             const aimWX = camX + input.aimX / zoom;
             const aimWY = camY + input.aimY / zoom;
             ws.send(
@@ -1090,6 +1120,9 @@
         lastHp = 100;
         state = { players: [], bullets: [], arena };
         updatePlayerList([]);
+        hideDeathScreen();
+        roundActive = false;
+        restartRaidBtn.disabled = false;
       }
 
       // Smoothing map for positions (reduces 20Hz stutter)
@@ -1805,6 +1838,10 @@
         for (const p of state.players) {
           const sp = getSmoothedPos(p.id, p.x, p.y, dt);
           ctx.save();
+          if (p.role === "streamer" && p.alive === false) {
+            ctx.restore();
+            continue;
+          }
           if (p.role === "streamer") {
             ctx.strokeStyle = "#4caf50";
             ctx.beginPath();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1077,6 +1077,111 @@ body.game {
   text-align: right;
 }
 
+/* Raid end overlay (join clients) */
+.raid-end-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(6, 8, 12, 0.82);
+  backdrop-filter: blur(6px);
+}
+
+.raid-end-card {
+  width: min(420px, 90vw);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 28px 32px;
+  border-radius: 16px;
+  border: 1px solid rgba(244, 114, 182, 0.35);
+  background: linear-gradient(
+    160deg,
+    rgba(18, 18, 24, 0.95) 0%,
+    rgba(28, 18, 24, 0.92) 100%
+  );
+  box-shadow: 0 22px 40px rgba(0, 0, 0, 0.45);
+  text-align: center;
+}
+
+.raid-end-title {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--pink);
+}
+
+.raid-end-description {
+  margin: 0;
+  font-size: 15px;
+  color: var(--muted);
+}
+
+.raid-end-label {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.raid-end-leaderboard ol {
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.raid-end-leaderboard li {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  font-size: 15px;
+}
+
+.raid-end-rank {
+  font-weight: 700;
+  color: rgba(244, 114, 182, 0.9);
+}
+
+.raid-end-name {
+  text-align: left;
+}
+
+.raid-end-score {
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.raid-end-empty {
+  margin: 0;
+  padding: 12px 0 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.raid-end-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.raid-end-leave {
+  background: linear-gradient(180deg, rgba(239, 83, 80, 0.85), rgba(183, 28, 28, 0.9));
+  border-color: rgba(239, 83, 80, 0.4);
+}
+
+.raid-end-leave:hover {
+  border-color: rgba(239, 83, 80, 0.6);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.08) inset,
+    0 12px 26px rgba(239, 83, 80, 0.35);
+}
+
 /* Death Screen */
 .death-screen {
   position: fixed;

--- a/src/room/systems/ai-zombies.ts
+++ b/src/room/systems/ai-zombies.ts
@@ -261,12 +261,10 @@ export function aiZombieAttackStreamer(ctx: RoomDO, zombie: AIZombie, streamer: 
     // Add damage number for zombie hit on streamer
     ctx.addDamageNumber(streamer.pos.x, streamer.pos.y, ctx.cfg.combat.zombieTouchDamage, false, false);
   }
-  
+
   if ((streamer.hp ?? 0) <= 0) {
-    // Respawn streamer; lose unbanked on death (keep banked)
-    streamer.pos = ctx.spawnInRandomRoom();
-    streamer.hp = streamer.maxHp ?? ctx.cfg.streamer.maxHp;
-    streamer.score = 0;
+    ctx.handleStreamerDeath(streamer, 'ai_zombie_touch');
+    return;
   }
   
   // Knockback streamer slightly

--- a/src/room/systems/broadcast.ts
+++ b/src/room/systems/broadcast.ts
@@ -52,6 +52,7 @@ export function broadcastState(ctx: RoomDO) {
     arena: { w: ctx.W, h: ctx.H },
     remainingTime: Math.max(0, Math.floor(((ctx.roundEndTime || Date.now()) - Date.now()) / 1000)),
     chatEnabled: ctx.chatEnabled,
+    roundActive: ctx.roundActive,
   };
   const msg = JSON.stringify(snapshot);
   for (const p of ctx.players.values()) {


### PR DESCRIPTION
## Summary
- add round lifecycle controls that mark the streamer dead, broadcast round_end events, and rebuild the arena when the streamer restarts
- reset AI and player placement on restart while broadcasting the new map and round status to every client
- teach the streamer and join clients to respect round_end/round_restart messages, freeze inputs when a raid ends, and relaunch clean UI state for a fresh match

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cd492a8c1483208816bc94d0095cd4