### PR TITLE
Add shared weapon proc system

### DIFF
--- a/src/room/systems/combat.ts
+++ b/src/room/systems/combat.ts
@@ -77,7 +77,7 @@ export function processDotEffects(ctx: RoomDO, now: number) {
           const owner = ctx.players.get(e.ownerId);
           // Lifesteal on DoT damage
           if (owner && owner.role==='streamer') {
-            const s = statsFor(owner).s;
+            const { s } = statsFor(owner);
             if (s.lifestealPct>0) {
               const heal = Math.max(0, Math.floor(e.dps * s.lifestealPct));
               owner.hp = Math.min(owner.maxHp ?? ctx.cfg.streamer.maxHp, (owner.hp ?? ctx.cfg.streamer.maxHp) + heal);
@@ -93,7 +93,7 @@ export function processDotEffects(ctx: RoomDO, now: number) {
             const id = z.id;
             setTimeout(()=>{ const zp=ctx.players.get(id); if (zp){ zp.pos=ctx.spawnZombiePos(); zp.alive=true; zp.zHp=zp.zMaxHp; } }, ctx.cfg.combat.respawnMs);
             if (owner && owner.role==='streamer') {
-              const s = statsFor(owner).s;
+              const { s } = statsFor(owner);
               if (s.reloadOnKillPct>0) ctx.refundAmmoOnKill(owner, s.reloadOnKillPct);
             }
             continue; // don't keep this effect
@@ -112,7 +112,7 @@ export function processDotEffects(ctx: RoomDO, now: number) {
           z.zHp = Math.max(0, (z.zHp ?? ctx.cfg.zombies.baseHp) - e.dps);
           const owner = ctx.players.get(e.ownerId);
           if (owner && owner.role==='streamer') {
-            const s = statsFor(owner).s;
+            const { s } = statsFor(owner);
             if (s.lifestealPct>0) {
               const heal = Math.max(0, Math.floor(e.dps * s.lifestealPct));
               owner.hp = Math.min(owner.maxHp ?? ctx.cfg.streamer.maxHp, (owner.hp ?? ctx.cfg.streamer.maxHp) + heal);
@@ -128,7 +128,7 @@ export function processDotEffects(ctx: RoomDO, now: number) {
             const id = z.id;
             setTimeout(()=>{ const zp=ctx.players.get(id); if (zp){ zp.pos=ctx.spawnZombiePos(); zp.alive=true; zp.zHp=zp.zMaxHp; } }, ctx.cfg.combat.respawnMs);
             if (owner && owner.role==='streamer') {
-              const s = statsFor(owner).s;
+              const { s } = statsFor(owner);
               if (s.reloadOnKillPct>0) ctx.refundAmmoOnKill(owner, s.reloadOnKillPct);
             }
             continue;
@@ -150,7 +150,7 @@ export function processDotEffects(ctx: RoomDO, now: number) {
           a.hp = Math.max(0, a.hp - e.dps);
           const owner = ctx.players.get(e.ownerId);
           if (owner && owner.role==='streamer') {
-            const s = statsFor(owner).s;
+            const { s } = statsFor(owner);
             if (s.lifestealPct>0) {
               const heal = Math.max(0, Math.floor(e.dps * s.lifestealPct));
               owner.hp = Math.min(owner.maxHp ?? ctx.cfg.streamer.maxHp, (owner.hp ?? ctx.cfg.streamer.maxHp) + heal);
@@ -162,7 +162,7 @@ export function processDotEffects(ctx: RoomDO, now: number) {
           }
           if (a.hp <= 0) {
             if (owner && owner.role==='streamer') {
-              const s = statsFor(owner).s;
+              const { s } = statsFor(owner);
               if (s.reloadOnKillPct>0) ctx.refundAmmoOnKill(owner, s.reloadOnKillPct);
             }
             continue; // killed; removal handled in updateAIZombies
@@ -181,7 +181,7 @@ export function processDotEffects(ctx: RoomDO, now: number) {
           a.hp = Math.max(0, a.hp - e.dps);
           const owner = ctx.players.get(e.ownerId);
           if (owner && owner.role==='streamer') {
-            const s = statsFor(owner).s;
+            const { s } = statsFor(owner);
             if (s.lifestealPct>0) {
               const heal = Math.max(0, Math.floor(e.dps * s.lifestealPct));
               owner.hp = Math.min(owner.maxHp ?? ctx.cfg.streamer.maxHp, (owner.hp ?? ctx.cfg.streamer.maxHp) + heal);
@@ -193,7 +193,7 @@ export function processDotEffects(ctx: RoomDO, now: number) {
           }
           if (a.hp <= 0) {
             if (owner && owner.role==='streamer') {
-              const s = statsFor(owner).s;
+              const { s } = statsFor(owner);
               if (s.reloadOnKillPct>0) ctx.refundAmmoOnKill(owner, s.reloadOnKillPct);
             }
             continue;
@@ -281,7 +281,7 @@ export function applyChainDamage(ctx: RoomDO, b: Bullet, from: {x:number;y:numbe
         }
         
         // Refund ammo if applicable
-        const s = statsFor(owner).s;
+        const { s } = statsFor(owner);
         if (s && s.reloadOnKillPct > 0) {
           ctx.refundAmmoOnKill(owner, s.reloadOnKillPct);
         }

--- a/src/room/systems/weapon-procs.ts
+++ b/src/room/systems/weapon-procs.ts
@@ -1,0 +1,127 @@
+import type { RoomDO } from '../index';
+import type { Player, Bullet } from '../room-types';
+import type { BulletSpawnSpec, StatBlock, WeaponProcInstance } from '../../types';
+import { WEAPON_PROC_INDEX } from '../../weapon-procs';
+import type { WeaponProcDef } from '../../types';
+
+const ensureCooldownMap = (owner: Player) => {
+  const key = '_procCooldowns';
+  const store = (owner as any)[key];
+  if (store) return store as Record<string, number>;
+  (owner as any)[key] = {};
+  return (owner as any)[key] as Record<string, number>;
+};
+
+const computeTriggerCount = (owner: Player, def: WeaponProcDef, chance: number) => {
+  if (!owner) return 0;
+  const normalized = Math.max(0, chance);
+  if (normalized <= 0) return 0;
+  const cooldowns = ensureCooldownMap(owner);
+  const now = Date.now();
+  if (def.cooldownMs) {
+    const readyAt = cooldowns[def.id] ?? 0;
+    if (readyAt > now) return 0;
+  }
+  let triggers = 0;
+  if (normalized >= 1) {
+    triggers = Math.floor(normalized);
+    const fractional = normalized - triggers;
+    if (Math.random() < fractional) triggers += 1;
+  } else if (Math.random() < normalized) {
+    triggers = 1;
+  }
+  if (triggers > 0 && def.cooldownMs) {
+    cooldowns[def.id] = now + def.cooldownMs;
+  }
+  return triggers;
+};
+
+const buildContextBase = (room: RoomDO, owner: Player, stats: StatBlock, instance: WeaponProcInstance) => ({
+  room,
+  owner,
+  stats,
+  instance,
+});
+
+export function triggerProcsOnShoot(
+  room: RoomDO,
+  owner: Player | undefined,
+  weapon: string | undefined,
+  bullets: BulletSpawnSpec[],
+  stats: StatBlock | undefined,
+  procs: WeaponProcInstance[] | undefined,
+) {
+  if (!owner || !stats || !procs?.length) return;
+  for (const proc of procs) {
+    const def = WEAPON_PROC_INDEX[proc.id];
+    if (!def?.events?.onShoot) continue;
+    const triggers = computeTriggerCount(owner, def, proc.chance);
+    for (let i = 0; i < triggers; i++) {
+      def.events.onShoot({
+        ...buildContextBase(room, owner, stats, proc),
+        weapon,
+        bullets,
+      });
+    }
+  }
+}
+
+export function triggerProcsOnHit(
+  room: RoomDO,
+  owner: Player | undefined,
+  bullet: Bullet,
+  stats: StatBlock | undefined,
+  procs: WeaponProcInstance[] | undefined,
+  details: {
+    targetId?: string;
+    targetType?: 'playerZombie' | 'aiZombie' | 'boss';
+    killed?: boolean;
+    impact: { x: number; y: number };
+  },
+) {
+  if (!owner || !stats || !procs?.length) return;
+  for (const proc of procs) {
+    const def = WEAPON_PROC_INDEX[proc.id];
+    if (!def?.events?.onHit) continue;
+    const triggers = computeTriggerCount(owner, def, proc.chance);
+    for (let i = 0; i < triggers; i++) {
+      def.events.onHit({
+        ...buildContextBase(room, owner, stats, proc),
+        bullet,
+        targetId: details.targetId,
+        targetType: details.targetType,
+        killed: details.killed,
+        impact: details.impact,
+      });
+    }
+  }
+}
+
+export function triggerProcsOnKill(
+  room: RoomDO,
+  owner: Player | undefined,
+  bullet: Bullet | undefined,
+  stats: StatBlock | undefined,
+  procs: WeaponProcInstance[] | undefined,
+  details: {
+    victimId: string;
+    targetType?: 'playerZombie' | 'aiZombie' | 'boss';
+    impact: { x: number; y: number };
+  },
+) {
+  if (!owner || !stats || !procs?.length) return;
+  for (const proc of procs) {
+    const def = WEAPON_PROC_INDEX[proc.id];
+    if (!def?.events?.onKill) continue;
+    const triggers = computeTriggerCount(owner, def, proc.chance);
+    for (let i = 0; i < triggers; i++) {
+      def.events.onKill({
+        ...buildContextBase(room, owner, stats, proc),
+        victimId: details.victimId,
+        bullet,
+        targetType: details.targetType,
+        impact: details.impact,
+      });
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,25 @@ export type ModId =
   | 'magnet_radius' | 'on_extract_refund' | 'ammo_efficiency'
   | 'movement_speed' | 'dash_distance' | 'double_jump' | 'ghost_walk'
   | 'berserker' | 'vampire_aura' | 'time_dilation' | 'bullet_time'
-  | 'explosive_death' | 'shield_regen';
+  | 'explosive_death' | 'shield_regen'
+  | 'void_hooks' | 'volatile_payload' | 'sanguine_cycle';
 
 export type Rarity = 'common'|'uncommon'|'rare'|'epic'|'legendary';
+
+export type WeaponProcId =
+  | 'arc_burst'
+  | 'gravity_snare'
+  | 'volatile_core'
+  | 'siphon_bloom';
+
+export interface WeaponProcGrant {
+  id: WeaponProcId;
+  flatChance?: number;
+  chancePerStack?: number;
+  maxChance?: number;
+  flatPotency?: number;
+  potencyPerStack?: number;
+}
 
 export interface ModDef {
   id: ModId;
@@ -24,6 +40,8 @@ export interface ModDef {
   apply?: (s: StatBlock, stacks: number) => void;
   // Event hooks (optional):
   hooks?: Partial<ModHooks>;
+  // Proc-based effects that can be shared across weapons
+  weaponProcs?: WeaponProcGrant[];
 }
 
 export interface StatBlock {
@@ -67,6 +85,13 @@ export interface ModHooks {
   onHit?: (ctx: HitContext) => void;
   // Invoked when a zombie dies
   onKill?: (ctx: KillContext) => void;
+}
+
+export interface WeaponProcInstance {
+  id: WeaponProcId;
+  stacks: number;
+  chance: number;
+  potency: number;
 }
 
 export interface ShotContext {
@@ -115,6 +140,48 @@ export interface BulletSpawnSpec {
   };
 }
 export type ActiveBullet = BulletSpawnSpec & { id: string };
+
+export interface WeaponProcContextBase {
+  room: any;
+  owner: any;
+  instance: WeaponProcInstance;
+  stats: StatBlock;
+}
+
+export interface WeaponProcShootContext extends WeaponProcContextBase {
+  weapon?: string;
+  bullets: BulletSpawnSpec[];
+}
+
+export interface WeaponProcHitContext extends WeaponProcContextBase {
+  bullet: ActiveBullet;
+  targetId?: string;
+  targetType?: 'playerZombie' | 'aiZombie' | 'boss';
+  killed?: boolean;
+  impact: { x: number; y: number };
+}
+
+export interface WeaponProcKillContext extends WeaponProcContextBase {
+  victimId: string;
+  bullet?: ActiveBullet;
+  targetType?: 'playerZombie' | 'aiZombie' | 'boss';
+  impact: { x: number; y: number };
+}
+
+export interface WeaponProcHooks {
+  onShoot?: (ctx: WeaponProcShootContext) => void;
+  onHit?: (ctx: WeaponProcHitContext) => void;
+  onKill?: (ctx: WeaponProcKillContext) => void;
+}
+
+export interface WeaponProcDef {
+  id: WeaponProcId;
+  name: string;
+  description: string;
+  flavor?: string;
+  cooldownMs?: number;
+  events: WeaponProcHooks;
+}
 
 export type ZombieClass = "runner" | "brute" | "spitter" | "stalker" | "bomber";
 

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,26 +1,64 @@
-import { ModDef, ModHooks, ModId, Rarity, StatBlock, WeaponProcInstance, WeaponProcId } from "./types";
+import {
+  ModDef,
+  ModHooks,
+  ModId,
+  Rarity,
+  StatBlock,
+  WeaponProcInstance,
+  WeaponProcId,
+} from "./types";
 
 // XP pacing
 export const XP_PER_KILL = 1;
-export const XP_THRESHOLDS = (lvl:number)=> 3 + Math.floor(lvl*1.8); // small, fast roguelite loops
+export const XP_THRESHOLDS = (lvl: number) => 3 + Math.floor(lvl * 1.8); // small, fast roguelite loops
 
 // Base stats and aggregation
 export function baseStats(): StatBlock {
   return {
-    damageMul: 1, fireRateMul: 1, projectileSpeedMul: 1,
-    bulletSizeMul: 1, spreadMul: 1, knockbackMul: 1,
-    critChance: 0, critMul: 1.5, pierce: 0, bounce: 0, ricochet: 0, split: 0, chain: 0,
-    burnChance: 0, burnDps: 0, burnMs: 0,
-    slowChance: 0, slowMul: 1, slowMs: 0,
-    bleedChance: 0, bleedDps: 0, bleedMs: 0,
-    reloadOnKillPct: 0, lifestealPct: 0, ammoEfficiencyMul: 1, magnetBonus: 0, dashReloadPct: 0,
+    damageMul: 1,
+    fireRateMul: 1,
+    projectileSpeedMul: 1,
+    bulletSizeMul: 1,
+    spreadMul: 1,
+    knockbackMul: 1,
+    critChance: 0,
+    critMul: 1.5,
+    pierce: 0,
+    bounce: 0,
+    ricochet: 0,
+    split: 0,
+    chain: 0,
+    burnChance: 0,
+    burnDps: 0,
+    burnMs: 0,
+    slowChance: 0,
+    slowMul: 1,
+    slowMs: 0,
+    bleedChance: 0,
+    bleedDps: 0,
+    bleedMs: 0,
+    reloadOnKillPct: 0,
+    lifestealPct: 0,
+    ammoEfficiencyMul: 1,
+    magnetBonus: 0,
+    dashReloadPct: 0,
     // New stats for advanced upgrades
-    movementSpeedMul: 1, dashDistanceMul: 1, ghostWalkMs: 0, berserkerStacks: 0,
-    vampireAuraRange: 0, timeDilationMs: 0, bulletTimeMs: 0, explosiveDeathDamage: 0, shieldRegenRate: 0
+    movementSpeedMul: 1,
+    dashDistanceMul: 1,
+    ghostWalkMs: 0,
+    berserkerStacks: 0,
+    vampireAuraRange: 0,
+    timeDilationMs: 0,
+    bulletTimeMs: 0,
+    explosiveDeathDamage: 0,
+    shieldRegenRate: 0,
   };
 }
 
-export function statsFor(p: any): { s: StatBlock; procs: WeaponProcInstance[] } {
+export function statsFor(p: any): {
+  s: StatBlock;
+  procs: WeaponProcInstance[];
+} {
   const s = baseStats();
   const mods: Partial<Record<ModId, number>> = p?.mods || {};
   const procMap: Partial<Record<WeaponProcId, WeaponProcInstance>> = {};
@@ -37,15 +75,18 @@ export function statsFor(p: any): { s: StatBlock; procs: WeaponProcInstance[] } 
         };
         existing.stacks += stacks;
         if (grant.flatChance) existing.chance += grant.flatChance;
-        if (grant.chancePerStack) existing.chance += grant.chancePerStack * stacks;
-        if (grant.maxChance !== undefined) existing.chance = Math.min(existing.chance, grant.maxChance);
+        if (grant.chancePerStack)
+          existing.chance += grant.chancePerStack * stacks;
+        if (grant.maxChance !== undefined)
+          existing.chance = Math.min(existing.chance, grant.maxChance);
         if (grant.flatPotency) existing.potency += grant.flatPotency;
-        if (grant.potencyPerStack) existing.potency += grant.potencyPerStack * stacks;
+        if (grant.potencyPerStack)
+          existing.potency += grant.potencyPerStack * stacks;
         procMap[grant.id] = existing;
       }
     }
   }
-  const procs = Object.values(procMap).map(proc => ({
+  const procs = Object.values(procMap).map((proc) => ({
     ...proc,
     chance: Math.max(0, Math.min(proc.chance, 1)),
     potency: Math.max(0, proc.potency),
@@ -55,98 +96,393 @@ export function statsFor(p: any): { s: StatBlock; procs: WeaponProcInstance[] } 
 
 export function statusFrom(s: StatBlock) {
   const st: any = {};
-  if (s.burnMs && s.burnDps && s.burnChance) { st.burnMs = s.burnMs; st.burnDps = s.burnDps; st.burnChance = s.burnChance; }
-  if (s.slowMs && s.slowMul && s.slowChance) { st.slowMs = s.slowMs; st.slowMul = s.slowMul; st.slowChance = s.slowChance; }
-  if (s.bleedMs && s.bleedDps && s.bleedChance) { st.bleedMs = s.bleedMs; st.bleedDps = s.bleedDps; st.bleedChance = s.bleedChance; }
+  if (s.burnMs && s.burnDps && s.burnChance) {
+    st.burnMs = s.burnMs;
+    st.burnDps = s.burnDps;
+    st.burnChance = s.burnChance;
+  }
+  if (s.slowMs && s.slowMul && s.slowChance) {
+    st.slowMs = s.slowMs;
+    st.slowMul = s.slowMul;
+    st.slowChance = s.slowChance;
+  }
+  if (s.bleedMs && s.bleedDps && s.bleedChance) {
+    st.bleedMs = s.bleedMs;
+    st.bleedDps = s.bleedDps;
+    st.bleedChance = s.bleedChance;
+  }
   return Object.keys(st).length ? st : undefined;
 }
 
 // Upgrade catalog
 export const MODS: ModDef[] = [
-  { id:'damage_up', name:'+15% Damage', rarity:'common', desc:'All weapons deal 15% more damage.',
-    apply:(s,k)=>{ s.damageMul *= Math.pow(1.15, k); } },
-  { id:'firerate_up', name:'+20% Fire Rate', rarity:'common', desc:'Shoot faster.',
-    apply:(s,k)=>{ s.fireRateMul *= Math.pow(1.2, k); } },
-  { id:'bullet_size', name:'Bigger Bullets', rarity:'uncommon', desc:'+20% bullet size per stack.',
-    apply:(s,k)=>{ s.bulletSizeMul *= Math.pow(1.2, k); } },
-  { id:'spread_down', name:'Tighter Spread', rarity:'uncommon', desc:'-15% spread.',
-    apply:(s,k)=>{ s.spreadMul *= Math.pow(0.85, k); } },
-  { id:'pierce', name:'Piercing', rarity:'rare', desc:'+1 pierce per stack.',
-    apply:(s,k)=>{ s.pierce += k; } },
-  { id:'bounce', name:'Bouncy Bullets', rarity:'rare', desc:'+1 wall bounce.',
-    apply:(s,k)=>{ s.bounce += k; } },
-  { id:'crit_chance', name:'Criticals', rarity:'rare', desc:'+10% crit chance (+50% crit dmg).',
-    apply:(s,k)=>{ s.critChance += 0.10*k; s.critMul = Math.max(s.critMul, 1.5); } },
-  { id:'status_burn', name:'Incendiary', rarity:'rare', desc:'Bullets have 15% to ignite (12 DPS for 3s).',
-    apply:(s,k)=>{ s.burnChance += 0.15*k; s.burnDps = Math.max(s.burnDps, 12); s.burnMs = Math.max(s.burnMs, 3000); } },
-  { id:'status_slow', name:'Cryo Rounds', rarity:'uncommon', desc:'15% chance to slow (40% for 2s).',
-    apply:(s,k)=>{ s.slowChance += 0.15*k; s.slowMul = Math.min(s.slowMul, 0.6); s.slowMs = Math.max(s.slowMs, 2000); } },
-  { id:'lifesteal', name:'Lifesteal', rarity:'epic', desc:'Heal 2% of damage dealt.',
-    apply:(s,k)=>{ s.lifestealPct += 0.02*k; } },
-  { id:'reload_on_kill', name:'Adrenaline', rarity:'epic', desc:'Refund 10% ammo on kill.',
-    apply:(s,k)=>{ s.reloadOnKillPct += 0.10*k; } },
-  { id:'on_hit_explode', name:'Micro-grenades', rarity:'epic', desc:'Small explosion on hit.',
-    hooks:{ onHit: ({room,bullet}) => { (room as any).spawnSmallExplosion?.(bullet); } } },
-  { id:'chain_lightning', name:'Storm Chorus', rarity:'rare', desc:'On-hit chance to arc stormlight between foes.',
-    weaponProcs:[{ id:'arc_burst', flatChance:0.06, chancePerStack:0.04, maxChance:0.45, flatPotency:1, potencyPerStack:0.75 }] },
-  { id:'void_hooks', name:'Umbral Net', rarity:'epic', desc:'Impact points lash nearby zombies toward the strike.',
-    weaponProcs:[{ id:'gravity_snare', flatChance:0.05, chancePerStack:0.03, maxChance:0.35, flatPotency:1, potencyPerStack:0.6 }] },
-  { id:'volatile_payload', name:'Volatile Payload', rarity:'epic', desc:'Killing blows may detonate the target.',
-    weaponProcs:[{ id:'volatile_core', flatChance:0.08, chancePerStack:0.05, maxChance:0.5, flatPotency:1, potencyPerStack:0.5 }] },
-  { id:'sanguine_cycle', name:'Sanguine Cycle', rarity:'uncommon', desc:'Chance to siphon a surge of health on hit.',
-    weaponProcs:[{ id:'siphon_bloom', flatChance:0.1, chancePerStack:0.06, maxChance:0.55, flatPotency:1, potencyPerStack:0.45 }] },
-  { id:'shotgun_extra_pellet', name:'+Pellets', rarity:'uncommon', desc:'+1 shotgun pellet.',
-    hooks:{ onShoot: ({bullets}) => { /* can be implemented to add an extra pellet where appropriate */ } } },
-  { id:'smg_stability', name:'SMG Stability', rarity:'common', desc:'SMG spread −20%.',
-    apply:(s,k)=>{ s.spreadMul *= Math.pow(0.8, k); } },
-  { id:'pistol_precision', name:'Pistol Precision', rarity:'common', desc:'Pistol crit chance +15%.',
-    apply:(s,k)=>{ s.critChance += 0.15*k; } },
-  { id:'dash_reload', name:'Combat Slide', rarity:'rare', desc:'Dashing reloads 20% ammo.',
-    apply:(s,k)=>{ s.dashReloadPct += 0.2*k; } },
-  { id:'ammo_efficiency', name:'Ammo Saver', rarity:'uncommon', desc:'Shots cost 10% less ammo.',
-    apply:(s,k)=>{ s.ammoEfficiencyMul *= Math.pow(0.9, k); } },
-  { id:'magnet_radius', name:'Loot Vacuum', rarity:'common', desc:'+40px pickup radius UI hint.',
-    apply:(s,k)=>{ s.magnetBonus += 40*k; } },
-  
+  {
+    id: "damage_up",
+    name: "+15% Damage",
+    rarity: "common",
+    desc: "All weapons deal 15% more damage.",
+    apply: (s, k) => {
+      s.damageMul *= Math.pow(1.15, k);
+    },
+  },
+  {
+    id: "firerate_up",
+    name: "+20% Fire Rate",
+    rarity: "common",
+    desc: "Shoot faster.",
+    apply: (s, k) => {
+      s.fireRateMul *= Math.pow(1.2, k);
+    },
+  },
+  {
+    id: "bullet_size",
+    name: "Bigger Bullets",
+    rarity: "uncommon",
+    desc: "+20% bullet size per stack.",
+    apply: (s, k) => {
+      s.bulletSizeMul *= Math.pow(1.2, k);
+    },
+  },
+  {
+    id: "spread_down",
+    name: "Tighter Spread",
+    rarity: "uncommon",
+    desc: "-15% spread.",
+    apply: (s, k) => {
+      s.spreadMul *= Math.pow(0.85, k);
+    },
+  },
+  {
+    id: "pierce",
+    name: "Piercing",
+    rarity: "rare",
+    desc: "+1 pierce per stack.",
+    apply: (s, k) => {
+      s.pierce += k;
+    },
+  },
+  {
+    id: "bounce",
+    name: "Bouncy Bullets",
+    rarity: "rare",
+    desc: "+1 wall bounce.",
+    apply: (s, k) => {
+      s.bounce += k;
+    },
+  },
+  {
+    id: "crit_chance",
+    name: "Criticals",
+    rarity: "rare",
+    desc: "+10% crit chance (+50% crit dmg).",
+    apply: (s, k) => {
+      s.critChance += 0.1 * k;
+      s.critMul = Math.max(s.critMul, 1.5);
+    },
+  },
+  {
+    id: "status_burn",
+    name: "Incendiary",
+    rarity: "rare",
+    desc: "Bullets have 15% to ignite (12 DPS for 3s).",
+    apply: (s, k) => {
+      s.burnChance += 0.15 * k;
+      s.burnDps = Math.max(s.burnDps, 12);
+      s.burnMs = Math.max(s.burnMs, 3000);
+    },
+  },
+  {
+    id: "status_slow",
+    name: "Cryo Rounds",
+    rarity: "uncommon",
+    desc: "15% chance to slow (40% for 2s).",
+    apply: (s, k) => {
+      s.slowChance += 0.15 * k;
+      s.slowMul = Math.min(s.slowMul, 0.6);
+      s.slowMs = Math.max(s.slowMs, 2000);
+    },
+  },
+  {
+    id: "lifesteal",
+    name: "Lifesteal",
+    rarity: "epic",
+    desc: "Heal 2% of damage dealt.",
+    apply: (s, k) => {
+      s.lifestealPct += 0.02 * k;
+    },
+  },
+  {
+    id: "reload_on_kill",
+    name: "Adrenaline",
+    rarity: "epic",
+    desc: "Refund 10% ammo on kill.",
+    apply: (s, k) => {
+      s.reloadOnKillPct += 0.1 * k;
+    },
+  },
+  {
+    id: "on_hit_explode",
+    name: "Micro-grenades",
+    rarity: "epic",
+    desc: "Small explosion on hit.",
+    hooks: {
+      onHit: ({ room, bullet }) => {
+        (room as any).spawnSmallExplosion?.(bullet);
+      },
+    },
+  },
+  {
+    id: "chain_lightning",
+    name: "Storm Chorus",
+    rarity: "rare",
+    desc: "On-hit chance to arc stormlight between foes.",
+    weaponProcs: [
+      {
+        id: "arc_burst",
+        flatChance: 0.06,
+        chancePerStack: 0.04,
+        maxChance: 0.45,
+        flatPotency: 1,
+        potencyPerStack: 0.75,
+      },
+    ],
+  },
+  {
+    id: "void_hooks",
+    name: "Umbral Net",
+    rarity: "epic",
+    desc: "Impact points lash nearby zombies toward the strike.",
+    weaponProcs: [
+      {
+        id: "gravity_snare",
+        flatChance: 0.05,
+        chancePerStack: 0.03,
+        maxChance: 0.35,
+        flatPotency: 1,
+        potencyPerStack: 0.6,
+      },
+    ],
+  },
+  {
+    id: "volatile_payload",
+    name: "Volatile Payload",
+    rarity: "epic",
+    desc: "Killing blows may detonate the target.",
+    weaponProcs: [
+      {
+        id: "volatile_core",
+        flatChance: 0.08,
+        chancePerStack: 0.05,
+        maxChance: 0.5,
+        flatPotency: 1,
+        potencyPerStack: 0.5,
+      },
+    ],
+  },
+  {
+    id: "sanguine_cycle",
+    name: "Sanguine Cycle",
+    rarity: "uncommon",
+    desc: "Chance to siphon a surge of health on hit.",
+    weaponProcs: [
+      {
+        id: "siphon_bloom",
+        flatChance: 0.1,
+        chancePerStack: 0.06,
+        maxChance: 0.55,
+        flatPotency: 1,
+        potencyPerStack: 0.45,
+      },
+    ],
+  },
+  {
+    id: "shotgun_extra_pellet",
+    name: "+Pellets",
+    rarity: "uncommon",
+    desc: "+1 shotgun pellet.",
+    hooks: {
+      onShoot: ({ bullets }) => {
+        /* can be implemented to add an extra pellet where appropriate */
+      },
+    },
+  },
+  {
+    id: "smg_stability",
+    name: "SMG Stability",
+    rarity: "common",
+    desc: "SMG spread −20%.",
+    apply: (s, k) => {
+      s.spreadMul *= Math.pow(0.8, k);
+    },
+  },
+  {
+    id: "pistol_precision",
+    name: "Pistol Precision",
+    rarity: "common",
+    desc: "Pistol crit chance +15%.",
+    apply: (s, k) => {
+      s.critChance += 0.15 * k;
+    },
+  },
+  {
+    id: "dash_reload",
+    name: "Combat Slide",
+    rarity: "rare",
+    desc: "Dashing reloads 20% ammo.",
+    apply: (s, k) => {
+      s.dashReloadPct += 0.2 * k;
+    },
+  },
+  {
+    id: "ammo_efficiency",
+    name: "Ammo Saver",
+    rarity: "uncommon",
+    desc: "Shots cost 10% less ammo.",
+    apply: (s, k) => {
+      s.ammoEfficiencyMul *= Math.pow(0.9, k);
+    },
+  },
+  {
+    id: "magnet_radius",
+    name: "Loot Vacuum",
+    rarity: "common",
+    desc: "+40px pickup radius UI hint.",
+    apply: (s, k) => {
+      s.magnetBonus += 40 * k;
+    },
+  },
+
   // New fun upgrades
-  { id:'movement_speed', name:'Swift Feet', rarity:'common', desc:'+25% movement speed.',
-    apply:(s,k)=>{ s.movementSpeedMul *= Math.pow(1.25, k); } },
-  { id:'dash_distance', name:'Long Dash', rarity:'uncommon', desc:'+50% dash distance.',
-    apply:(s,k)=>{ s.dashDistanceMul *= Math.pow(1.5, k); } },
-  { id:'double_jump', name:'Air Walker', rarity:'rare', desc:'Dash resets on kill (simulates double jump).',
-    hooks:{ onKill: ({room,killerId}) => { const p = (room as any).players?.get(killerId); if (p) p.lastDashAt = 0; } } },
-  { id:'ghost_walk', name:'Phase Step', rarity:'epic', desc:'Brief invulnerability after dash (0.5s).',
-    apply:(s,k)=>{ s.ghostWalkMs += 500*k; } },
-  { id:'berserker', name:'Berserker Rage', rarity:'rare', desc:'+10% damage per recent kill (max 5 stacks).',
-    apply:(s,k)=>{ s.berserkerStacks += 5*k; } },
-  { id:'vampire_aura', name:'Blood Aura', rarity:'epic', desc:'Heal from nearby zombie deaths (+50px range).',
-    apply:(s,k)=>{ s.vampireAuraRange += 50*k; } },
-  { id:'time_dilation', name:'Bullet Time', rarity:'legendary', desc:'Slow time on low health (2s duration).',
-    apply:(s,k)=>{ s.timeDilationMs += 2000*k; } },
-  { id:'bullet_time', name:'Matrix Mode', rarity:'legendary', desc:'Slow projectiles when dashing (1s).',
-    apply:(s,k)=>{ s.bulletTimeMs += 1000*k; } },
-  { id:'explosive_death', name:'Martyrdom', rarity:'rare', desc:'Explode on death dealing 50 damage.',
-    apply:(s,k)=>{ s.explosiveDeathDamage += 50*k; } },
-  { id:'shield_regen', name:'Auto-Repair', rarity:'uncommon', desc:'Regenerate 1 HP every 3 seconds.',
-    apply:(s,k)=>{ s.shieldRegenRate += k; } },
+  {
+    id: "movement_speed",
+    name: "Swift Feet",
+    rarity: "common",
+    desc: "+25% movement speed.",
+    apply: (s, k) => {
+      s.movementSpeedMul *= Math.pow(1.25, k);
+    },
+  },
+  {
+    id: "dash_distance",
+    name: "Long Dash",
+    rarity: "uncommon",
+    desc: "+50% dash distance.",
+    apply: (s, k) => {
+      s.dashDistanceMul *= Math.pow(1.5, k);
+    },
+  },
+  {
+    id: "double_jump",
+    name: "Air Walker",
+    rarity: "rare",
+    desc: "Dash resets on kill (simulates double jump).",
+    hooks: {
+      onKill: ({ room, killerId }) => {
+        const p = (room as any).players?.get(killerId);
+        if (p) p.lastDashAt = 0;
+      },
+    },
+  },
+  {
+    id: "ghost_walk",
+    name: "Phase Step",
+    rarity: "epic",
+    desc: "Brief invulnerability after dash (0.5s).",
+    apply: (s, k) => {
+      s.ghostWalkMs += 500 * k;
+    },
+  },
+  {
+    id: "berserker",
+    name: "Berserker Rage",
+    rarity: "rare",
+    desc: "+10% damage per recent kill (max 5 stacks).",
+    apply: (s, k) => {
+      s.berserkerStacks += 5 * k;
+    },
+  },
+  {
+    id: "vampire_aura",
+    name: "Blood Aura",
+    rarity: "epic",
+    desc: "Heal from nearby zombie deaths (+50px range).",
+    apply: (s, k) => {
+      s.vampireAuraRange += 50 * k;
+    },
+  },
+  {
+    id: "time_dilation",
+    name: "Bullet Time",
+    rarity: "legendary",
+    desc: "Slow time on low health (2s duration).",
+    apply: (s, k) => {
+      s.timeDilationMs += 2000 * k;
+    },
+  },
+  {
+    id: "bullet_time",
+    name: "Matrix Mode",
+    rarity: "legendary",
+    desc: "Slow projectiles when dashing (1s).",
+    apply: (s, k) => {
+      s.bulletTimeMs += 1000 * k;
+    },
+  },
+  {
+    id: "explosive_death",
+    name: "Martyrdom",
+    rarity: "rare",
+    desc: "Explode on death dealing 50 damage.",
+    apply: (s, k) => {
+      s.explosiveDeathDamage += 50 * k;
+    },
+  },
+  {
+    id: "shield_regen",
+    name: "Auto-Repair",
+    rarity: "uncommon",
+    desc: "Regenerate 1 HP every 3 seconds.",
+    apply: (s, k) => {
+      s.shieldRegenRate += k;
+    },
+  },
 ];
 
-export const MOD_INDEX: Record<ModId, ModDef> = Object.fromEntries(MODS.map(m=>[m.id,m])) as any;
+export const MOD_INDEX: Record<ModId, ModDef> = Object.fromEntries(
+  MODS.map((m) => [m.id, m])
+) as any;
 
 // Rolling choices for offers
-export function rollChoices(current: Partial<Record<ModId,number>>, rng: () => number): ModDef[] {
-  const weights: Record<Rarity, number> = { common: 70, uncommon: 22, rare: 6, epic: 1.8, legendary: 0.2 };
-  const pool = MODS.map(m => ({ m, w: weights[m.rarity] }));
+export function rollChoices(
+  current: Partial<Record<ModId, number>>,
+  rng: () => number
+): ModDef[] {
+  const weights: Record<Rarity, number> = {
+    common: 70,
+    uncommon: 22,
+    rare: 6,
+    epic: 1.8,
+    legendary: 0.2,
+  };
+  const pool = MODS.map((m) => ({ m, w: weights[m.rarity] }));
   const picks: ModDef[] = [];
-  for (let i=0; i<3; i++){
-    let total = pool.reduce((s,p)=> s+p.w, 0);
-    let r = rng()*total;
+  for (let i = 0; i < 3; i++) {
+    let total = pool.reduce((s, p) => s + p.w, 0);
+    let r = rng() * total;
     let chosen: ModDef | null = null;
-    for (const p of pool) { r -= p.w; if (r<=0){ chosen = p.m; break; } }
-    if (!chosen) chosen = pool[pool.length-1].m;
-    if (picks.some(x=>x.id===chosen!.id)) { i--; continue; }
+    for (const p of pool) {
+      r -= p.w;
+      if (r <= 0) {
+        chosen = p.m;
+        break;
+      }
+    }
+    if (!chosen) chosen = pool[pool.length - 1].m;
+    if (picks.some((x) => x.id === chosen!.id)) {
+      i--;
+      continue;
+    }
     picks.push(chosen);
   }
   return picks;
 }
-  

--- a/src/weapon-procs.ts
+++ b/src/weapon-procs.ts
@@ -1,0 +1,129 @@
+import type { WeaponProcDef, WeaponProcId } from './types';
+
+const clampChance = (value: number) => Math.max(0, Math.min(1, value));
+
+export const WEAPON_PROCS: WeaponProcDef[] = [
+  {
+    id: 'arc_burst',
+    name: 'Arc Burst',
+    description: 'Chain a burst of stormlight between nearby foes.',
+    cooldownMs: 250,
+    events: {
+      onHit: (ctx) => {
+        if (!ctx?.room?.applyChainDamage) return;
+        const potency = Math.max(0, ctx.instance.potency || 0);
+        const chains = Math.max(1, Math.round(1 + potency));
+        const baseDamage = ctx.bullet?.meta?.damage || 0;
+        const damageScale = 0.45 + 0.12 * potency;
+        const damage = Math.max(6, Math.round(baseDamage * damageScale));
+        const impact = ctx.impact || { x: ctx.bullet.pos.x, y: ctx.bullet.pos.y };
+        const exclude = ctx.targetId || '';
+        ctx.room.applyChainDamage(ctx.bullet, impact, exclude, chains, damage);
+      },
+    },
+  },
+  {
+    id: 'gravity_snare',
+    name: 'Gravity Snare',
+    description: 'A void tether tugs and slows nearby zombies.',
+    cooldownMs: 300,
+    events: {
+      onHit: (ctx) => {
+        const room = ctx.room;
+        if (!room) return;
+        const potency = Math.max(0, ctx.instance.potency || 0);
+        const radius = 140 + 20 * potency;
+        const slowMs = 900 + 180 * potency;
+        const pullStrength = 0.16 + 0.04 * potency;
+        const maxTargets = 3 + Math.floor(potency);
+        const now = Date.now();
+        const center = ctx.impact || { x: ctx.bullet.pos.x, y: ctx.bullet.pos.y };
+        let affected = 0;
+
+        const pullPlayerZombie = (z: any) => {
+          if (!z || z.role !== 'zombie' || !z.alive) return;
+          const dx = center.x - z.pos.x;
+          const dy = center.y - z.pos.y;
+          const dist = Math.hypot(dx, dy);
+          if (dist > radius || dist === 0) return;
+          const ratio = pullStrength * (1 - dist / radius);
+          z.pos.x += dx * ratio;
+          z.pos.y += dy * ratio;
+          z.slowUntil = Math.max(z.slowUntil || 0, now + slowMs);
+          z.slowMul = Math.min(z.slowMul ?? 1, 0.55);
+          affected++;
+        };
+
+        const pullAIZombie = (z: any) => {
+          if (!z) return;
+          const dx = center.x - z.pos.x;
+          const dy = center.y - z.pos.y;
+          const dist = Math.hypot(dx, dy);
+          if (dist > radius || dist === 0) return;
+          const ratio = pullStrength * (1 - dist / radius);
+          z.pos.x += dx * ratio;
+          z.pos.y += dy * ratio;
+          z.slowUntil = Math.max(z.slowUntil || 0, now + slowMs);
+          z.slowMul = Math.min(z.slowMul ?? 1, 0.55);
+          affected++;
+        };
+
+        for (const z of room.players?.values?.() || []) {
+          if (affected >= maxTargets) break;
+          pullPlayerZombie(z);
+        }
+
+        if (affected < maxTargets) {
+          for (const z of room.aiZombies || []) {
+            if (affected >= maxTargets) break;
+            pullAIZombie(z);
+          }
+        }
+      },
+    },
+  },
+  {
+    id: 'volatile_core',
+    name: 'Volatile Core',
+    description: 'Killing blows can rupture into a volatile nova.',
+    cooldownMs: 300,
+    events: {
+      onKill: (ctx) => {
+        if (!ctx?.room?.createExplosion) return;
+        const potency = Math.max(0, ctx.instance.potency || 0);
+        const center = ctx.impact || (ctx.bullet ? { x: ctx.bullet.pos.x, y: ctx.bullet.pos.y } : null);
+        if (!center) return;
+        const baseDamage = ctx.bullet?.meta?.damage || 0;
+        const damageMul = 0.9 + 0.25 * potency;
+        const damage = Math.max(10, Math.round(baseDamage * damageMul));
+        const radius = 60 + 12 * potency;
+        const ownerId = ctx.owner?.id || ctx.bullet?.ownerId || '';
+        ctx.room.createExplosion(center.x, center.y, damage, radius, ownerId);
+      },
+    },
+  },
+  {
+    id: 'siphon_bloom',
+    name: 'Siphon Bloom',
+    description: 'A blooming siphon heals the shooter beyond basic lifesteal.',
+    cooldownMs: 150,
+    events: {
+      onHit: (ctx) => {
+        const owner = ctx.owner;
+        const room = ctx.room;
+        if (!owner || owner.role !== 'streamer' || !room) return;
+        const potency = Math.max(0, ctx.instance.potency || 0);
+        const baseDamage = ctx.bullet?.meta?.damage || 0;
+        const healAmount = Math.max(1, Math.round(baseDamage * (0.06 + 0.04 * potency)));
+        const maxHp = owner.maxHp ?? room.cfg?.streamer?.maxHp ?? 100;
+        owner.hp = Math.min(maxHp, (owner.hp ?? maxHp) + healAmount);
+      },
+    },
+  },
+];
+
+export const WEAPON_PROC_INDEX: Record<WeaponProcId, WeaponProcDef> = Object.fromEntries(
+  WEAPON_PROCS.map((proc) => [proc.id, proc])
+) as Record<WeaponProcId, WeaponProcDef>;
+
+export const clampProcChance = clampChance;


### PR DESCRIPTION
## Summary
- add weapon proc types and allow mods to grant proc effects alongside stats
- define reusable proc behaviors such as arc burst chaining, gravity snares, volatile cores, and siphon blooms
- integrate proc triggering into the firing and hit loops with cached stat snapshots and cooldown-aware execution

## Testing
- not run (no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68cddb2f12d883208c22f7aec2c952d2